### PR TITLE
[codex] Add UI design rules to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,16 @@ AI coding work in this repository must stay small, issue-driven, and scoped to t
 - `fix/*`: bug fixes and regressions.
 - `docs/*`: documentation-only changes.
 
+## UI and Design Rules
+
+For UI-related changes, always read and follow `DESIGN.md`.
+
+Do not introduce unrelated visual styles, new UI libraries, or broad redesigns unless explicitly requested by the GitHub Issue.
+
+Each UI task should stay limited to the page, section, or component group described in the Issue.
+
+Do not copy visual references pixel-by-pixel. Use them only as design direction and convert them into maintainable implementation.
+
 ## Development Commands
 
 - `npm start`: run the local development server on port 3000.


### PR DESCRIPTION
## Summary
Adds a concise `UI and Design Rules` section to `AGENTS.md`.

## Related Issue
Closes #8

## Why
This makes `AGENTS.md` direct future UI-related work to follow `DESIGN.md` and keeps visual changes scoped to the GitHub Issue.

## How to Test
- Verified `AGENTS.md` contains the new `UI and Design Rules` section.
- Compared `docs/update-agents-ui-design-rules` against `main` and confirmed the only changed file is `AGENTS.md`.
- No runtime tests run because this is a documentation-only change.

## Screenshots, if UI change
Not applicable; no UI or application code changed.

## Checklist
- [x] Read AGENTS.md first
- [x] Keep changes small and issue-driven
- [x] Do not modify unrelated files
- [x] Do not create extra markdown files
- [x] Do not commit secrets or .env files
- [x] Tests or manual checks were completed and documented above

## Risk
Low. Documentation-only update with no runtime behavior impact. Rollback is reverting the `AGENTS.md` section.

## Follow-up
None.