### PR TITLE
docs: add post-merge cleanup rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,45 @@ AI coding work in this repository must stay small, issue-driven, and scoped to t
 - `fix/*`: bug fixes and regressions.
 - `docs/*`: documentation-only changes.
 
+## Post-Merge Cleanup Rules
+
+After a PR is successfully merged, clean up the PR head branch when it is safe to do so.
+
+Delete both:
+
+- the remote PR branch
+- the local PR branch
+
+Only clean up branches that clearly belong to the merged PR and match these work branch patterns:
+
+- `feature/*`
+- `fix/*`
+- `docs/*`
+
+Do not delete:
+
+- `main`
+- `master`
+- `develop`
+- `release/*`
+- `production/*`
+- protected branches
+- branches that are not clearly the merged PR head branch
+- branches with unmerged or uncertain work
+
+Recommended cleanup commands when safe:
+
+```bash
+git checkout main
+git pull origin main
+git branch -d <branch-name>
+git push origin --delete <branch-name>
+```
+
+Do not use `git branch -D` unless the user explicitly approves a force delete.
+
+If the environment or tool cannot delete the branch, report the exact branch name and the manual cleanup commands needed.
+
 ## UI and Design Rules
 
 For UI-related changes, always read and follow `DESIGN.md`.


### PR DESCRIPTION
## Summary
Add post-merge cleanup rules to `AGENTS.md`.

## Related Issue
Closes #11

## Why
Make the branch cleanup policy explicit so merged PR branches are removed safely and consistently.

## How to Test
Docs-only change. Verify the diff contains only `AGENTS.md` and no application files were modified.

## Risk
Low. This updates repository guidance only and does not affect runtime behavior.

## Follow-up
No follow-up required unless the branch strategy or cleanup workflow changes again.

## Changed files
- `AGENTS.md`