### PR TITLE
Improve tablet responsive styles

### DIFF
--- a/src/components/GalleryWithText/styles.jsx
+++ b/src/components/GalleryWithText/styles.jsx
@@ -115,6 +115,16 @@ export const GalleryDotsWrapper = styled.div`
   width: auto;
   margin: 0;
   z-index: 2;
+
+  @media (max-width: 1024px) {
+    gap: 14px;
+    max-width: calc(100% - 32px);
+  }
+
+  @media (max-width: 500px) {
+    gap: 12px;
+    max-width: calc(100% - 24px);
+  }
 `;
 
 export const GalleryDot = styled.button`
@@ -129,6 +139,14 @@ export const GalleryDot = styled.button`
   transition: background 0.2s;
   &.active {
     background: #e60012;
+  }
+
+  @media (max-width: 1024px) {
+    width: 64px;
+  }
+
+  @media (max-width: 500px) {
+    width: 48px;
   }
 `;
 

--- a/src/components/Navbar/styles.jsx
+++ b/src/components/Navbar/styles.jsx
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 
 const hideMobile = css`
-  @media (max-width: 900px) {
+  @media (max-width: 1024px) {
     display: none !important;
   }
 `;
@@ -19,6 +19,15 @@ export const Nav = styled.nav`
   position: relative;
   transition: all 0.3s ease-in-out;
   z-index: 1000;
+
+  @media (max-width: 1024px) {
+    padding: 0 1.5rem;
+    min-height: 72px;
+  }
+
+  @media (min-width: 1025px) and (max-width: 1180px) {
+    padding: 0.75rem 1.5rem;
+  }
 
   ${({ $isSticky }) =>
     $isSticky &&
@@ -39,6 +48,10 @@ export const Brand = styled.div`
   transform: translateY(-50%);
   display: flex;
   align-items: center;
+
+  @media (max-width: 1024px) {
+    left: 1.5rem;
+  }
 
   @media (max-width: 425px) {
     left: 20px;
@@ -70,6 +83,18 @@ export const LogoImg = styled.img`
       height: 60px;
     `}
 
+  @media (min-width: 1025px) and (max-width: 1180px) {
+    width: 76px;
+    height: 76px;
+    object-fit: contain;
+  }
+
+  @media (max-width: 1024px) {
+    width: 72px;
+    height: 72px;
+    object-fit: contain;
+  }
+
   @media (max-width: 500px) {
     height: 60px;
     width: 60px;
@@ -100,6 +125,15 @@ export const LinkItem = styled.li`
   &.hide-mobile {
     ${hideMobile}
   }
+
+  @media (min-width: 1025px) and (max-width: 1180px) {
+    margin: 0 5px;
+
+    a {
+      font-size: 0.92rem;
+      padding: 6px 7px;
+    }
+  }
 `;
 
 export const MainLinks = styled(Links)`
@@ -108,7 +142,11 @@ export const MainLinks = styled(Links)`
   display: flex;
   justify-content: center; // Center the main links
 
-  @media (max-width: 900px) {
+  @media (min-width: 1025px) and (max-width: 1180px) {
+    margin-left: 96px;
+  }
+
+  @media (max-width: 1024px) {
     display: none; // Hide earlier to prevent squeezing/wrapping
   }
 `;
@@ -127,10 +165,10 @@ export const HamburgerIcon = styled.div`
     transition: 0.4s;
   }
 
-  @media (max-width: 900px) {
+  @media (max-width: 1024px) {
     display: block; // Show on tablet/mobile screens
     position: absolute;
-    right: 2rem;
+    right: 1.5rem;
     top: 50%;
     transform: translateY(-50%);
   }
@@ -159,12 +197,21 @@ export const MenuOverlay = styled.div`
   &.open {
     transform: translateX(0);
   }
+
+  @media (max-width: 1024px) {
+    padding-top: 76px;
+    padding-bottom: 32px;
+  }
+
+  @media (max-width: 500px) {
+    padding-top: 72px;
+  }
 `;
 
 export const CloseIcon = styled.div`
   position: absolute;
   top: 20px;
-  right: 80px;
+  right: clamp(20px, 4vw, 48px);
   cursor: pointer;
   font-size: 2rem;
   color: #333;
@@ -191,6 +238,11 @@ export const MenuItem = styled(LinkItem)`
     padding: 15px 0; // Larger padding
     font-size: 1.2rem; // Larger font size
   }
+
+  @media (max-width: 1024px) {
+    width: min(82%, 480px);
+    margin: 12px 0;
+  }
 `;
 // Dropdown Styles
 export const DropdownContainer = styled.div`
@@ -202,8 +254,8 @@ export const DropdownContainer = styled.div`
     ${hideMobile}
   }
 
-  @media (max-width: 900px) {
-    width: 80%;
+  @media (max-width: 1024px) {
+    width: min(82%, 480px);
     margin: 15px 0;
   }
 `;
@@ -224,7 +276,7 @@ export const DropdownButton = styled.button`
     color: #e30613;
   }
 
-  @media (max-width: 900px) {
+  @media (max-width: 1024px) {
     font-size: 1.2rem;
     width: 100%;
     justify-content: center;
@@ -257,7 +309,7 @@ export const DropdownMenu = styled.ul`
     }
   }
 
-  @media (max-width: 900px) {
+  @media (max-width: 1024px) {
     position: static;
     box-shadow: none;
     width: 100%;
@@ -293,7 +345,7 @@ export const DropdownItem = styled.li`
     }
   `}
 
-  @media (max-width: 900px) {
+  @media (max-width: 1024px) {
     width: 100%;
     text-align: center;
     padding: 12px 0;

--- a/src/pages/ExplorePage/styles.jsx
+++ b/src/pages/ExplorePage/styles.jsx
@@ -2,6 +2,14 @@ import styled from "styled-components";
 
 export const Container = styled.div`
   padding: 2rem;
+
+  @media (max-width: 1024px) {
+    padding: 1.5rem;
+  }
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+  }
 `;
 
 export const ExploreBanner = styled.div`
@@ -29,6 +37,16 @@ export const ExploreTitle = styled.h2`
   margin: 0;
   white-space: pre-line;
   text-align: center;
+
+  @media (max-width: 1024px) {
+    font-size: 1.35rem;
+    line-height: 28px;
+  }
+
+  @media (max-width: 768px) {
+    font-size: 1.2rem;
+    line-height: 26px;
+  }
 `;
 
 export const ExploreList = styled.ul`
@@ -120,9 +138,16 @@ export const ArticleSection = styled.section`
   align-items: stretch;
   padding: 2.5rem 1rem;
   background: #fff;
+
+  @media (max-width: 1024px) {
+    gap: 1.5rem;
+    padding: 2rem 1.5rem;
+  }
+
   @media (max-width: 900px) {
     flex-direction: column;
     min-height: unset;
+    gap: 0;
   }
 `;
 
@@ -132,6 +157,12 @@ export const ArticleLeft = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
+
+  @media (max-width: 1024px) {
+    flex: 0.9;
+    padding: 0 1.5rem;
+  }
+
   @media (max-width: 900px) {
     padding: 1.5rem 1rem 0 1rem;
   }
@@ -144,6 +175,11 @@ export const ArticleRight = styled.div`
   align-items: center;
   justify-content: center;
   background: #f7f7f7;
+
+  @media (max-width: 1024px) {
+    flex: 1.25;
+  }
+
   @media (max-width: 900px) {
     padding: 1rem 0 2rem 0;
   }
@@ -161,12 +197,25 @@ export const ArticleTitle = styled.h2`
   &:hover {
     color: #e10012;
   }
+
+  @media (max-width: 1024px) {
+    font-size: 1.7rem;
+  }
+
+  @media (max-width: 768px) {
+    font-size: 1.45rem;
+  }
 `;
 
 export const ArticleDesc = styled.p`
   font-size: 1.1rem;
   color: #222;
   margin-bottom: 1.5rem;
+
+  @media (max-width: 1024px) {
+    font-size: 1rem;
+    line-height: 1.6;
+  }
 `;
 
 export const ArticleTag = styled.div`
@@ -235,6 +284,12 @@ export const ArticleButton = styled.button`
     color: #fff;
     text-decoration: none;
   }
+  @media (max-width: 1024px) {
+    width: 190px;
+    height: 50px;
+    padding: 0 18px;
+    font-size: 1.05rem;
+  }
   @media (max-width: 500px) {
     width: 150px;
     max-width: 150px;
@@ -251,6 +306,20 @@ export const ArticleImage = styled.img`
   border-radius: 0;
   object-fit: cover;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+
+  @media (max-width: 1024px) {
+    min-height: 280px;
+  }
+
+  @media (max-width: 900px) {
+    height: auto;
+    max-height: 420px;
+    min-height: 260px;
+  }
+
+  @media (max-width: 768px) {
+    min-height: 220px;
+  }
 `;
 
 export const FourColumnSection = styled.section`
@@ -259,11 +328,16 @@ export const FourColumnSection = styled.section`
   gap: 1.5rem;
   padding: 2.5rem;
 
+  @media (max-width: 1024px) {
+    gap: 1.25rem;
+    padding: 2rem;
+  }
+
   @media (max-width: 1200px) {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 767px) {
     grid-template-columns: 1fr;
     padding: 1.5rem;
   }
@@ -287,6 +361,18 @@ export const FourColumnImage = styled.img`
   width: 100%;
   height: 200px;
   object-fit: cover;
+
+  @media (max-width: 1024px) {
+    height: 180px;
+  }
+
+  @media (max-width: 768px) {
+    height: 210px;
+  }
+
+  @media (max-width: 500px) {
+    height: 180px;
+  }
 `;
 
 export const FourColumnContent = styled.div`

--- a/src/pages/HSPage/styles.jsx
+++ b/src/pages/HSPage/styles.jsx
@@ -3,12 +3,32 @@ import { HomeLinkButton } from "../Home/styles";
 
 export const Container = styled.div`
   padding: 2rem;
+
+  @media (max-width: 1024px) {
+    padding: 1.5rem;
+  }
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+  }
 `;
 
 export const HeroImageWrapper = styled.div`
   position: relative;
   width: 100%;
   height: 480px;
+
+  @media (max-width: 1024px) {
+    height: 420px;
+  }
+
+  @media (max-width: 768px) {
+    height: 360px;
+  }
+
+  @media (max-width: 500px) {
+    height: 480px;
+  }
 `;
 
 export const HeroImage = styled.img`
@@ -29,19 +49,28 @@ export const HeroNavBar = styled.nav`
   z-index: 10;
   height: 70px;
   border-bottom: 1.5px solid #e5e5e5;
-  @media (max-width: 768px) {
-    gap: 1.2rem;
-    height: 48px;
-    padding: 0 0.5rem;
-  }
-  @media (max-width: 500px) {
+
+  @media (max-width: 1024px) {
     justify-content: flex-start;
+    gap: 1.5rem;
+    height: 60px;
+    top: 72px;
+    padding: 0 1.5rem;
     overflow-x: auto;
     scrollbar-width: none;
     -ms-overflow-style: none;
+
     &::-webkit-scrollbar {
       display: none;
     }
+  }
+
+  @media (max-width: 768px) {
+    gap: 1rem;
+    height: 52px;
+    padding: 0 1rem;
+  }
+  @media (max-width: 500px) {
     position: relative; /* Ensure positioning context for pseudo-elements */
 
     &::before {
@@ -81,6 +110,7 @@ export const HeroNavItem = styled.button`
   font-size: 1.15rem;
   font-weight: 600;
   color: ${({ $active }) => ($active ? "#222" : "#919399")};
+  flex: 0 0 auto;
   padding: 0 0.5em 0.5em 0.5em;
   position: relative;
   cursor: pointer;
@@ -98,6 +128,11 @@ export const HeroNavItem = styled.button`
     display: ${({ $active }) => ($active ? "block" : "none")};
   }
 
+  @media (max-width: 1024px) {
+    font-size: 1.05rem;
+    padding: 0 0.4em 0.45em 0.4em;
+  }
+
   @media (max-width: 768px) {
     font-size: 0.98rem;
     padding: 0 0.3em 0.3em 0.3em;
@@ -108,6 +143,13 @@ export const SectionAnchor = styled.div`
   scroll-margin-top: 110px;
   min-height: 400px;
   margin: 40px 0;
+
+  @media (max-width: 1024px) {
+    scroll-margin-top: 104px;
+    min-height: 320px;
+    margin: 32px 0;
+  }
+
   @media (max-width: 768px) {
     min-height: 260px;
     margin: 24px 0;
@@ -120,6 +162,12 @@ export const DesignSectionTitle = styled.h2`
   font-weight: 700;
   margin: 0 0 5rem 0;
   letter-spacing: 2px;
+
+  @media (max-width: 1024px) {
+    font-size: 2rem;
+    margin: 0 0 3rem 0;
+  }
+
   @media (max-width: 768px) {
     margin: 0;
     font-size: 24px;
@@ -128,6 +176,14 @@ export const DesignSectionTitle = styled.h2`
 
 export const DetailSectionWrapper = styled.div`
   margin-top: 4rem;
+
+  @media (max-width: 1024px) {
+    margin-top: 3rem;
+  }
+
+  @media (max-width: 768px) {
+    margin-top: 2rem;
+  }
 `;
 
 export const DetailSectionTitle = styled.h2`
@@ -136,6 +192,15 @@ export const DetailSectionTitle = styled.h2`
   font-weight: 700;
   margin-bottom: 2.5rem;
   letter-spacing: 1.5px;
+
+  @media (max-width: 1024px) {
+    font-size: 1.75rem;
+    margin-bottom: 2rem;
+  }
+
+  @media (max-width: 768px) {
+    font-size: 1.5rem;
+  }
 `;
 
 export const PowerImage = styled.img`
@@ -145,6 +210,12 @@ export const PowerImage = styled.img`
 export const ExperienceTextWrapper = styled.div`
   text-align: center;
   margin-bottom: 3rem;
+
+  @media (max-width: 1024px) {
+    margin-bottom: 2rem;
+    padding: 0 1.5rem;
+  }
+
   @media (max-width: 500px) {
     padding: 0 1rem;
     text-align: left; // 行動裝置文字靠左對齊
@@ -157,8 +228,14 @@ export const PowerAccordionWrapper = styled.div`
 
 export const SafetySectionWrapper = styled.div`
   margin: 4rem 0;
+
+  @media (max-width: 1024px) {
+    margin: 3rem 0;
+  }
+
   @media (max-width: 500px) {
     margin: 1rem 0; // 調整行動裝置的
+  }
 `;
 
 export const SafetyCarouselWrapper = styled.div`
@@ -176,8 +253,14 @@ export const SafetyImageBlock = styled.div`
   flex-direction: column;
   align-items: center;
   margin-bottom: 2.5rem;
+
+  @media (max-width: 1024px) {
+    margin-bottom: 2rem;
+  }
+
   @media (max-width: 500px) {
   margin-bottom: 0; // 調整行動裝置的底部邊距
+  }
 `;
 
 export const SafetyImage = styled.img`
@@ -197,6 +280,11 @@ export const SafetyText = styled.p`
   line-height: 1.6; // 行高
   padding: 0 2rem; // 區塊內部的左右內邊距
   box-sizing: border-box; // 確保 padding 被包含在寬度計算之內
+
+  @media (max-width: 1024px) {
+    padding: 0 1.5rem;
+    width: 86%;
+  }
 
   @media (max-width: 768px) {
     font-size: 1rem;
@@ -270,6 +358,13 @@ export const SafetyCarouselWrapperStyled = styled.div`
         color: #c00;
       }
 
+      @media (max-width: 1024px) {
+        width: 190px;
+        height: 50px;
+        padding: 0 18px;
+        font-size: 1.05rem;
+      }
+
       @media (max-width: 500px) {
         position: static; // 行動裝置版面改為靜態定位
         width: 150px; // 根據圖片調整寬度 (基於內容)
@@ -289,6 +384,27 @@ export const SafetyCarouselWrapperStyled = styled.div`
         }
       }
     }
+    @media (max-width: 1024px) {
+      bottom: 48px;
+      left: 48px;
+      gap: 1rem;
+      max-width: 480px;
+
+      h1 {
+        font-size: 1.8rem;
+      }
+    }
+
+    @media (max-width: 768px) {
+      bottom: 36px;
+      left: 32px;
+      max-width: 420px;
+
+      h1 {
+        font-size: 1.55rem;
+      }
+    }
+
     @media (max-width: 500px) {
       position: static; /* Change from absolute to static for stacking */
       bottom: auto;
@@ -325,6 +441,12 @@ export const SafetyCarouselWrapperStyled = styled.div`
     bottom: 1rem;
     transform: translateX(-50%);
     z-index: 2;
+
+    @media (max-width: 1024px) {
+      gap: 22px;
+      bottom: 0.75rem;
+    }
+
     @media (max-width: 500px) {
       position: static;
       padding: 0;
@@ -370,6 +492,26 @@ export const ExperienceCarouselWrapperStyled = styled.div`
       line-height: 1.2;
     }
 
+    @media (max-width: 1024px) {
+      bottom: 48px;
+      left: 48px;
+      max-width: 480px;
+
+      h1 {
+        font-size: 1.8rem;
+      }
+    }
+
+    @media (max-width: 768px) {
+      bottom: 36px;
+      left: 32px;
+      max-width: 420px;
+
+      h1 {
+        font-size: 1.55rem;
+      }
+    }
+
     @media (max-width: 500px) {
       position: static;
       order: 2; // Text content is third
@@ -394,6 +536,15 @@ export const ExperienceCarouselWrapperStyled = styled.div`
     bottom: 200px; // Position dots above the text on desktop
     transform: translateX(-50%);
     z-index: 2;
+
+    @media (max-width: 1024px) {
+      bottom: 150px;
+      gap: 22px;
+    }
+
+    @media (max-width: 768px) {
+      bottom: 120px;
+    }
 
     @media (max-width: 500px) {
       position: static;

--- a/src/pages/ZSPage/styles.jsx
+++ b/src/pages/ZSPage/styles.jsx
@@ -3,12 +3,32 @@ import { HomeLinkButton } from "../Home/styles";
 
 export const Container = styled.div`
   padding: 2rem;
+
+  @media (max-width: 1024px) {
+    padding: 1.5rem;
+  }
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+  }
 `;
 
 export const HeroImageWrapper = styled.div`
   position: relative;
   width: 100%;
   height: 480px;
+
+  @media (max-width: 1024px) {
+    height: 420px;
+  }
+
+  @media (max-width: 768px) {
+    height: 360px;
+  }
+
+  @media (max-width: 500px) {
+    height: 480px;
+  }
 `;
 
 export const HeroImage = styled.img`
@@ -29,19 +49,28 @@ export const HeroNavBar = styled.nav`
   z-index: 10;
   height: 70px;
   border-bottom: 1.5px solid #e5e5e5;
-  @media (max-width: 768px) {
-    gap: 1.2rem;
-    height: 48px;
-    padding: 0 0.5rem;
-  }
-  @media (max-width: 500px) {
+
+  @media (max-width: 1024px) {
     justify-content: flex-start;
+    gap: 1.5rem;
+    height: 60px;
+    top: 72px;
+    padding: 0 1.5rem;
     overflow-x: auto;
     scrollbar-width: none;
     -ms-overflow-style: none;
+
     &::-webkit-scrollbar {
       display: none;
     }
+  }
+
+  @media (max-width: 768px) {
+    gap: 1rem;
+    height: 52px;
+    padding: 0 1rem;
+  }
+  @media (max-width: 500px) {
     position: relative;
     &::before {
       content: "";
@@ -79,6 +108,7 @@ export const HeroNavItem = styled.button`
   font-size: 1.15rem;
   font-weight: 600;
   color: ${({ $active }) => ($active ? "#222" : "#919399")};
+  flex: 0 0 auto;
   padding: 0 0.5em 0.5em 0.5em;
   position: relative;
   cursor: pointer;
@@ -98,6 +128,18 @@ export const HeroNavItem = styled.button`
     z-index: -3;
     display: ${({ $active }) => ($active ? "block" : "none")};
   }
+
+  @media (max-width: 1024px) {
+    font-size: 1.05rem;
+    min-width: 104px;
+    padding: 0 0.4em 0.45em 0.4em;
+  }
+
+  @media (max-width: 768px) {
+    font-size: 0.98rem;
+    min-width: 110px;
+  }
+
   @media (max-width: 500px) {
     font-size: 1rem;
     min-width: 110px;
@@ -111,6 +153,13 @@ export const SectionAnchor = styled.div`
   scroll-margin-top: 110px;
   min-height: 400px;
   margin: 40px 0;
+
+  @media (max-width: 1024px) {
+    scroll-margin-top: 104px;
+    min-height: 320px;
+    margin: 32px 0;
+  }
+
   @media (max-width: 768px) {
     min-height: 260px;
     margin: 24px 0;
@@ -123,6 +172,12 @@ export const DesignSectionTitle = styled.h2`
   font-weight: 700;
   margin: 3rem 0 5rem 0;
   letter-spacing: 2px;
+
+  @media (max-width: 1024px) {
+    font-size: 2rem;
+    margin: 2.5rem 0 3rem 0;
+  }
+
   @media (max-width: 500px) {
     font-size: 24px;
     line-height: 32px;
@@ -132,6 +187,14 @@ export const DesignSectionTitle = styled.h2`
 
 export const DetailSectionWrapper = styled.div`
   margin-top: 4rem;
+
+  @media (max-width: 1024px) {
+    margin-top: 3rem;
+  }
+
+  @media (max-width: 768px) {
+    margin-top: 2rem;
+  }
 `;
 
 export const DetailSectionTitle = styled.h2`
@@ -140,6 +203,15 @@ export const DetailSectionTitle = styled.h2`
   font-weight: 700;
   margin-bottom: 2.5rem;
   letter-spacing: 1.5px;
+
+  @media (max-width: 1024px) {
+    font-size: 1.75rem;
+    margin-bottom: 2rem;
+  }
+
+  @media (max-width: 768px) {
+    font-size: 1.5rem;
+  }
 `;
 
 export const PowerImage = styled.img`
@@ -149,6 +221,16 @@ export const PowerImage = styled.img`
 export const ExperienceTextWrapper = styled.div`
   text-align: center;
   margin-bottom: 3rem;
+
+  @media (max-width: 1024px) {
+    margin-bottom: 2rem;
+    padding: 0 1.5rem;
+  }
+
+  @media (max-width: 500px) {
+    padding: 0 1rem;
+    text-align: left;
+  }
 `;
 
 export const PowerAccordionWrapper = styled.div`
@@ -157,6 +239,14 @@ export const PowerAccordionWrapper = styled.div`
 
 export const SafetySectionWrapper = styled.div`
   margin: 4rem 0;
+
+  @media (max-width: 1024px) {
+    margin: 3rem 0;
+  }
+
+  @media (max-width: 500px) {
+    margin: 1rem 0;
+  }
 `;
 
 export const SafetyCarouselWrapper = styled.div`
@@ -174,6 +264,14 @@ export const SafetyImageBlock = styled.div`
   flex-direction: column;
   align-items: center;
   margin-bottom: 2.5rem;
+
+  @media (max-width: 1024px) {
+    margin-bottom: 2rem;
+  }
+
+  @media (max-width: 500px) {
+    margin-bottom: 0;
+  }
 `;
 
 export const SafetyImage = styled.img`
@@ -193,6 +291,11 @@ export const SafetyText = styled.p`
   line-height: 1.6; // 行高
   padding: 0 2rem; // 區塊內部的左右內邊距
   box-sizing: border-box; // 確保 padding 被包含在寬度計算之內
+
+  @media (max-width: 1024px) {
+    padding: 0 1.5rem;
+    width: 86%;
+  }
 
   @media (max-width: 768px) {
     font-size: 1rem;
@@ -265,6 +368,34 @@ export const SafetyCarouselWrapperStyled = styled.div`
       &:hover::after {
         color: #c00;
       }
+
+      @media (max-width: 1024px) {
+        width: 190px;
+        height: 50px;
+        padding: 0 18px;
+        font-size: 1.05rem;
+      }
+    }
+
+    @media (max-width: 1024px) {
+      bottom: 48px;
+      left: 48px;
+      gap: 1rem;
+      max-width: 480px;
+
+      h1 {
+        font-size: 1.8rem;
+      }
+    }
+
+    @media (max-width: 768px) {
+      bottom: 36px;
+      left: 32px;
+      max-width: 420px;
+
+      h1 {
+        font-size: 1.55rem;
+      }
     }
 
     @media (max-width: 500px) {
@@ -302,6 +433,11 @@ export const SafetyCarouselWrapperStyled = styled.div`
     bottom: 1rem;
     transform: translateX(-50%);
     z-index: 2;
+
+    @media (max-width: 1024px) {
+      gap: 22px;
+      bottom: 0.75rem;
+    }
   }
 `;
 
@@ -331,6 +467,27 @@ export const ExperienceCarouselWrapperStyled = styled.div`
       text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
       line-height: 1.2;
     }
+
+    @media (max-width: 1024px) {
+      bottom: 48px;
+      left: 48px;
+      gap: 1rem;
+      max-width: 480px;
+
+      h1 {
+        font-size: 1.8rem;
+      }
+    }
+
+    @media (max-width: 768px) {
+      bottom: 36px;
+      left: 32px;
+      max-width: 420px;
+
+      h1 {
+        font-size: 1.55rem;
+      }
+    }
   }
 
   .carousel-dots {
@@ -343,6 +500,11 @@ export const ExperienceCarouselWrapperStyled = styled.div`
     bottom: 1rem;
     transform: translateX(-50%);
     z-index: 2;
+
+    @media (max-width: 1024px) {
+      gap: 22px;
+      bottom: 0.75rem;
+    }
   }
 `;
 
@@ -370,6 +532,22 @@ export const ContextualText = styled.h1`
   font-weight: 400;
   letter-spacing: 0.3px;
   color: #fff;
+
+  @media (max-width: 1024px) {
+    width: 40%;
+    right: 36px;
+    bottom: 64px;
+    font-size: 1.75rem;
+    line-height: 1.25;
+  }
+
+  @media (max-width: 768px) {
+    width: 46%;
+    right: 28px;
+    bottom: 48px;
+    font-size: 1.5rem;
+  }
+
   @media (max-width: 500px) {
     width: 100%;
     color: #000;
@@ -390,6 +568,23 @@ export const OverlayText = styled.h1`
   font-size: 1rem;
   line-height: 24px;
   font-weight: 400;
+
+  @media (max-width: 1024px) {
+    width: 42%;
+    left: 36px;
+    top: 64px;
+    font-size: 0.95rem;
+    line-height: 22px;
+  }
+
+  @media (max-width: 768px) {
+    width: 50%;
+    left: 28px;
+    top: 48px;
+    font-size: 0.9rem;
+    line-height: 21px;
+  }
+
   @media (max-width: 500px) {
     width: 100%;
     color: #6d6f73;
@@ -427,6 +622,27 @@ export const SpaceCarouselWrapper = styled.div`
       line-height: 1.2;
     }
 
+    @media (max-width: 1024px) {
+      bottom: 48px;
+      left: 48px;
+      gap: 1rem;
+      max-width: 480px;
+
+      h1 {
+        font-size: 1.8rem;
+      }
+    }
+
+    @media (max-width: 768px) {
+      bottom: 36px;
+      left: 32px;
+      max-width: 420px;
+
+      h1 {
+        font-size: 1.55rem;
+      }
+    }
+
     @media (max-width: 500px) {
       position: static; /* Change from absolute to static for stacking */
       bottom: auto;
@@ -461,6 +677,11 @@ export const SpaceCarouselWrapper = styled.div`
     bottom: 1rem;
     transform: translateX(-50%);
     z-index: 2;
+
+    @media (max-width: 1024px) {
+      gap: 22px;
+      bottom: 0.75rem;
+    }
   }
 `;
 
@@ -470,6 +691,18 @@ export const SafetyTextOverlayWrapper = styled.div`
   left: 48px; /* Adjust as needed */
   z-index: 1;
   width: 40%; /* Adjust as needed */
+
+  @media (max-width: 1024px) {
+    top: 56px;
+    left: 36px;
+    width: 46%;
+  }
+
+  @media (max-width: 768px) {
+    top: 40px;
+    left: 28px;
+    width: 52%;
+  }
 
   @media (max-width: 500px) {
     position: static;
@@ -488,6 +721,11 @@ export const SafetyHeaderText = styled.h1`
   color: #333; /* Assuming white text on a dark image, adjust if image is light */
   margin-bottom: 1rem; /* Space between H1 and P */
 
+  @media (max-width: 1024px) {
+    font-size: 1.75rem;
+    line-height: 34px;
+  }
+
   @media (max-width: 500px) {
     font-size: 1.5rem; /* Adjust font size for mobile */
     line-height: 1.3;
@@ -500,6 +738,11 @@ export const SafetyParagraphText = styled.p`
   font-size: 1rem;
   line-height: 24px;
   color: #6d6f73; /* Assuming white text on a dark image, adjust if image is light */
+
+  @media (max-width: 1024px) {
+    font-size: 0.95rem;
+    line-height: 22px;
+  }
 
   @media (max-width: 500px) {
     font-size: 0.9rem; /* Adjust font size for mobile */


### PR DESCRIPTION
## Summary
- Added tablet-focused responsive styling for the navbar, HS page, ZS page, and Explore page.
- Kept the PR style-only and preserved existing desktop/mobile visual direction.
- Included a narrow GalleryWithText dots adjustment after QA found it caused direct horizontal overflow in the vehicle page tablet/mobile checks.

## Related Issue
Closes #13

## Why
Issue #13 asks for tablet responsive polish around the 768px-1024px range without changing app behavior. These changes improve navbar breakpoint handling, tablet hero/nav readability, carousel overlay spacing, and Explore article/grid balance while leaving JSX, routing, carousel data/behavior, assets, package files, and lockfiles untouched.

## How to Test
- `npm.cmd run build` - passed, production build compiled successfully.
- `npm run lint` - skipped because `package.json` has no lint script.
- Responsive QA via local production build with Playwright and system Chrome at `1440`, `1025`, `1024`, `912`, `820`, `768`, `500`, and `390` widths.
- Checked Home, HS, ZS, Explore, test-drive, contact, and order routes for horizontal overflow.
- Verified navbar desktop nav appears at `1025px` and above, hamburger appears at `1024px` and below, and the menu overlay opens without overflow.
- Verified Explore grid behavior: desktop 4 columns, tablet 2 columns including `768px`, mobile 1 column.

## Screenshots, if UI change
Before/after screenshot files are not attached. Responsive before/after notes: the tablet navbar now switches cleanly at `1024px`, HS/ZS tablet sections have reduced hero/nav/overlay spacing, Explore tablet cards remain two-column through `768px`, and the gallery dots no longer create horizontal overflow.

## Checklist
- [x] Read AGENTS.md first
- [x] Keep changes small and issue-driven
- [x] Do not modify unrelated files
- [x] Do not create extra markdown files
- [x] Do not commit secrets or .env files
- [x] Tests or manual checks were completed and documented above

## Risk
Low to medium. The change is CSS/styled-components only, but it touches responsive breakpoints around `1024px`, sticky page nav spacing, carousel overlay positioning, and shared GalleryWithText dot sizing. Rollback is reverting the style-only commit.

## Follow-up
Optional Issue-suggested files were not changed because no directly related tablet blocker was found in the final QA pass beyond the GalleryWithText dot overflow used by the vehicle pages.

## Changed files
- `src/components/Navbar/styles.jsx`
- `src/pages/HSPage/styles.jsx`
- `src/pages/ZSPage/styles.jsx`
- `src/pages/ExplorePage/styles.jsx`
- `src/components/GalleryWithText/styles.jsx`