### PR TITLE
fix: stabilize dealer page scrolling interaction (Issue #24)

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -22,27 +22,9 @@ import { useAuth } from "../../contexts/AuthContext";
 
 const Navbar = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isSticky, setIsSticky] = useState(false);
-  const [isScrolled, setIsScrolled] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const { isLoggedIn, logout } = useAuth();
   const dropdownRef = useRef(null);
-
-  const handleScroll = () => {
-    const scrollPosition = window.scrollY;
-    // Sticky logic
-    if (scrollPosition > 0) {
-      setIsSticky(true);
-    } else {
-      setIsSticky(false);
-    }
-    // Scrolled logic (10% of viewport height)
-    if (scrollPosition > window.innerHeight * 0.1) {
-      setIsScrolled(true);
-    } else {
-      setIsScrolled(false);
-    }
-  };
 
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -51,10 +33,8 @@ const Navbar = () => {
       }
     };
     window.addEventListener("mousedown", handleClickOutside);
-    window.addEventListener("scroll", handleScroll);
     return () => {
       window.removeEventListener("mousedown", handleClickOutside);
-      window.removeEventListener("scroll", handleScroll);
     };
   }, []);
 
@@ -158,14 +138,10 @@ const Navbar = () => {
   );
 
   return (
-    <Nav $isSticky={isSticky}>
+    <Nav>
       <Brand>
         <Link to="/">
-          <LogoImg
-            $isScrolled={isScrolled}
-            src="/media/navbar/logo.webp"
-            alt="MG Logo"
-          />
+          <LogoImg src="/media/navbar/logo.webp" alt="MG Logo" />
         </Link>
       </Brand>
 

--- a/src/components/Navbar/styles.jsx
+++ b/src/components/Navbar/styles.jsx
@@ -16,8 +16,10 @@ export const Nav = styled.nav`
   justify-content: space-between; // Ensure items spread out
   align-items: center;
   min-height: 64px;
-  position: relative;
-  transition: all 0.3s ease-in-out;
+  position: sticky;
+  top: 0;
+  transition: box-shadow 0.2s ease-in-out;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   z-index: 1000;
 
   @media (max-width: 1024px) {
@@ -29,15 +31,6 @@ export const Nav = styled.nav`
     padding: 0.75rem 1.5rem;
   }
 
-  ${({ $isSticky }) =>
-    $isSticky &&
-    `
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-  `}
 `;
 
 // Brand 絕對定位於左上角
@@ -71,17 +64,10 @@ export const Brand = styled.div`
 
 // Logo 圖片樣式統一管理
 export const LogoImg = styled.img`
-  width: 100%;
+  width: 100px;
   height: 100px;
-  object-fit: cover;
+  object-fit: contain;
   display: block;
-  transition: height 0.3s ease-in-out;
-
-  ${({ $isScrolled }) =>
-    $isScrolled &&
-    `
-      height: 60px;
-    `}
 
   @media (min-width: 1025px) and (max-width: 1180px) {
     width: 76px;

--- a/src/pages/DealerPage/DealerPage.jsx
+++ b/src/pages/DealerPage/DealerPage.jsx
@@ -86,7 +86,9 @@ const DealerPage = () => {
                 }
               }}
             >
-              {canEnableMapInteraction ? "啟用地圖操作" : "行動裝置已鎖定地圖"}
+              {canEnableMapInteraction
+                ? "啟用地圖操作"
+                : "行動裝置可上下滑動頁面，據點分類請使用下方按鈕"}
             </MapInteractionButton>
           </MapScrollShield>
         )}

--- a/src/pages/DealerPage/DealerPage.jsx
+++ b/src/pages/DealerPage/DealerPage.jsx
@@ -1,22 +1,26 @@
 import React from "react";
 import { GoogleMap, Marker, useJsApiLoader } from "@react-google-maps/api";
-import { MapOptionsWrapper, MapOptionsInner, MapOptionButton } from "./styles"; // 引入 styled-components
+import {
+  MapShell,
+  MapScrollShield,
+  MapInteractionButton,
+  MapOptionsWrapper,
+  MapOptionsInner,
+  MapOptionButton,
+} from "./styles";
 
 const allLocations = {
   show: [
     { lat: 25.033964, lng: 121.564472, name: "台北展示中心" },
     { lat: 24.147736, lng: 120.673648, name: "台中展示中心" },
-    // ...更多展示中心
   ],
   service: [
     { lat: 25.047675, lng: 121.517055, name: "台北服務中心" },
     { lat: 24.163162, lng: 120.639634, name: "台中服務中心" },
-    // ...更多服務中心
   ],
   charge: [
     { lat: 24.993628, lng: 121.301019, name: "新竹充電站" },
     { lat: 24.80395, lng: 120.9687, name: "苗栗充電站" },
-    // ...更多充電站
   ],
 };
 
@@ -27,41 +31,67 @@ const containerStyle = {
 };
 
 const center = { lat: 24.5, lng: 121 };
-const mapOptions = {
-  // Fully prevent map gestures from hijacking vertical page scrolling.
-  gestureHandling: "none",
-  scrollwheel: false,
-  draggable: false,
-  disableDoubleClickZoom: true,
-  keyboardShortcuts: false,
-};
 
 const DealerPage = () => {
   const { isLoaded } = useJsApiLoader({
     googleMapsApiKey: process.env.REACT_APP_GOOGLE_MAPS_API_KEY,
   });
   const [type, setType] = React.useState("show");
+  const [isMapInteractive, setIsMapInteractive] = React.useState(false);
+  const canEnableMapInteraction = React.useMemo(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+  }, []);
+  const shouldLockMap = !canEnableMapInteraction || !isMapInteractive;
   const locations = allLocations[type];
+
+  const mapOptions = {
+    // Keep page scroll stable by default; map gestures are opt-in.
+    gestureHandling: shouldLockMap ? "none" : "greedy",
+    scrollwheel: !shouldLockMap,
+    draggable: !shouldLockMap,
+    disableDoubleClickZoom: shouldLockMap,
+    keyboardShortcuts: !shouldLockMap,
+  };
 
   return (
     <div className="dealer-page">
-      {isLoaded && (
-        <GoogleMap
-          mapContainerStyle={containerStyle}
-          center={center}
-          zoom={8}
-          options={mapOptions}
-        >
-          {locations.map((loc, idx) => (
-            <Marker
-              key={idx}
-              position={{ lat: loc.lat, lng: loc.lng }}
-              title={loc.name}
-            />
-          ))}
-        </GoogleMap>
-      )}
-      {/* 地圖下方選項區塊 */}
+      <MapShell>
+        {isLoaded && (
+          <GoogleMap
+            mapContainerStyle={containerStyle}
+            center={center}
+            zoom={8}
+            options={mapOptions}
+            onMouseLeave={() => setIsMapInteractive(false)}
+          >
+            {locations.map((loc, idx) => (
+              <Marker
+                key={idx}
+                position={{ lat: loc.lat, lng: loc.lng }}
+                title={loc.name}
+              />
+            ))}
+          </GoogleMap>
+        )}
+
+        {shouldLockMap && (
+          <MapScrollShield>
+            <MapInteractionButton
+              type="button"
+              disabled={!canEnableMapInteraction}
+              onClick={() => {
+                if (canEnableMapInteraction) {
+                  setIsMapInteractive(true);
+                }
+              }}
+            >
+              {canEnableMapInteraction ? "啟用地圖操作" : "行動裝置已鎖定地圖"}
+            </MapInteractionButton>
+          </MapScrollShield>
+        )}
+      </MapShell>
+
       <MapOptionsWrapper>
         <MapOptionsInner>
           <MapOptionButton

--- a/src/pages/DealerPage/DealerPage.jsx
+++ b/src/pages/DealerPage/DealerPage.jsx
@@ -26,6 +26,11 @@ const containerStyle = {
 };
 
 const center = { lat: 24.5, lng: 121 };
+const mapOptions = {
+  // Prevent mouse-wheel/touch scroll from hijacking page scrolling.
+  gestureHandling: "cooperative",
+  scrollwheel: false,
+};
 
 const DealerPage = () => {
   const { isLoaded } = useJsApiLoader({
@@ -37,7 +42,12 @@ const DealerPage = () => {
   return (
     <div className="dealer-page">
       {isLoaded && (
-        <GoogleMap mapContainerStyle={containerStyle} center={center} zoom={8}>
+        <GoogleMap
+          mapContainerStyle={containerStyle}
+          center={center}
+          zoom={8}
+          options={mapOptions}
+        >
           {locations.map((loc, idx) => (
             <Marker
               key={idx}

--- a/src/pages/DealerPage/DealerPage.jsx
+++ b/src/pages/DealerPage/DealerPage.jsx
@@ -23,13 +23,17 @@ const allLocations = {
 const containerStyle = {
   width: "100%",
   height: "600px",
+  touchAction: "pan-y",
 };
 
 const center = { lat: 24.5, lng: 121 };
 const mapOptions = {
-  // Prevent mouse-wheel/touch scroll from hijacking page scrolling.
-  gestureHandling: "cooperative",
+  // Fully prevent map gestures from hijacking vertical page scrolling.
+  gestureHandling: "none",
   scrollwheel: false,
+  draggable: false,
+  disableDoubleClickZoom: true,
+  keyboardShortcuts: false,
 };
 
 const DealerPage = () => {

--- a/src/pages/DealerPage/styles.jsx
+++ b/src/pages/DealerPage/styles.jsx
@@ -18,13 +18,63 @@ export const HeroImage = styled.img`
   object-fit: cover;
 `;
 
+export const MapShell = styled.div`
+  position: relative;
+  width: 100%;
+  line-height: 0;
+  touch-action: pan-y;
+`;
+
+export const MapScrollShield = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 0 16px 24px;
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.2) 0%,
+    rgba(0, 0, 0, 0) 36%
+  );
+  pointer-events: auto;
+`;
+
+export const MapInteractionButton = styled.button`
+  pointer-events: auto;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  background: rgba(0, 0, 0, 0.78);
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.9);
+  }
+
+  &:disabled {
+    background: rgba(0, 0, 0, 0.58);
+    cursor: default;
+  }
+`;
+
 export const MapOptionsWrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
   position: relative;
-  margin-top: -70px;
-  z-index: 10;
+  margin-top: -56px;
+  padding: 0 16px 32px;
+  z-index: 2;
+
+  @media (max-width: 768px) {
+    margin-top: -44px;
+    padding-bottom: 24px;
+  }
 `;
 
 export const MapOptionsInner = styled.div`
@@ -33,6 +83,11 @@ export const MapOptionsInner = styled.div`
   border-radius: 6px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   overflow: hidden;
+
+  @media (max-width: 768px) {
+    width: 100%;
+    max-width: 360px;
+  }
 `;
 
 export const MapOptionButton = styled.button`
@@ -45,4 +100,10 @@ export const MapOptionButton = styled.button`
   cursor: pointer;
   border-right: ${({ last }) => (last ? "none" : "1px solid #eee")};
   transition: background 0.2s, color 0.2s;
+
+  @media (max-width: 768px) {
+    flex: 1;
+    padding: 14px 12px;
+    font-size: 1rem;
+  }
 `;

--- a/src/pages/DealerPage/styles.jsx
+++ b/src/pages/DealerPage/styles.jsx
@@ -31,13 +31,17 @@ export const MapScrollShield = styled.div`
   display: flex;
   align-items: flex-end;
   justify-content: center;
-  padding: 0 16px 24px;
+  padding: 0 16px 104px;
   background: linear-gradient(
     to top,
     rgba(0, 0, 0, 0.2) 0%,
     rgba(0, 0, 0, 0) 36%
   );
   pointer-events: auto;
+
+  @media (max-width: 768px) {
+    padding-bottom: 88px;
+  }
 `;
 
 export const MapInteractionButton = styled.button`


### PR DESCRIPTION
## Summary
- reduce full-page vertical scroll jitter on Dealer page by hardening map gesture handling and removing scroll-driven navbar layout transitions
- update mobile/touch map overlay copy to clearer guidance text

## Related Issue
- refs #24

## Why
- QA feedback still reported whole-page jitter during vertical scroll on `/dealer`
- previous map-only tuning was insufficient; navbar scroll state/layout transitions could also contribute to visible page shake
- mobile/touch overlay wording needed clearer user guidance for page scrolling + category selection

## Changed Files
- `src/pages/DealerPage/DealerPage.jsx`
- `src/pages/DealerPage/styles.jsx`
- `src/components/Navbar/Navbar.jsx`
- `src/components/Navbar/styles.jsx`

## What Changed
- Dealer map area:
  - added map interaction lock flow with overlay shield
  - lock map gestures by default and only allow explicit desktop interaction
  - prevent touch/wheel gesture pass-through that can hijack document scrolling
  - updated disabled mobile/touch overlay text to:
    - `行動裝置可上下滑動頁面，據點分類請使用下方按鈕`
- Navbar behavior:
  - removed JS scroll listener/state toggles for sticky/scrolled behavior
  - switched to stable CSS `position: sticky` behavior
  - removed scroll-driven logo height transition to avoid scroll-time layout shifts

## How to Test
1. Run `npm start`
2. Open `/dealer`
3. Test continuous vertical scrolling over map area at desktop + mobile widths (focus 390px)
4. Verify footer remains fully reachable and visible
5. Verify desktop map can still be interacted with after explicit enable action

## Validation
- `npm run build` ✅ pass

## Manual QA Checklist (Navbar Global Scope)
- [ ] Home: navbar visible, no unexpected layout shift
- [ ] HS: navbar visible, page content not blocked
- [ ] ZS: navbar visible, page content not blocked
- [ ] Dealer: vertical scroll stable over map area
- [ ] Explore/About/Test-drive/Order/Contact: navbar remains usable
- [ ] Mobile width around 390px: mobile menu opens/closes normally and Dealer page scroll remains stable

## Manual QA Result
- Not fully executed in this CLI-only run; checklist is added for final reviewer/manual device validation.

## Risk
- Navbar no longer uses previous scroll-driven logo shrink behavior (intentional to prioritize scroll stability)
- final acceptance still depends on manual device/browser QA for jitter reproduction path

## Out of Scope
- no dependency changes
- no env/deploy config changes
- no backend/API changes

## Follow-up
- if jitter is still reproducible on target device/browser, next fallback is to disable live Google Map interaction on touch devices and render a static/non-interactive map block there

## Scope Check
- changes are limited to Dealer page and Navbar components related to scroll behavior